### PR TITLE
fix: issue with windows and nodemon --exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "npm run generate-imported-components && parcel app/index.html --hmr-port 1235",
-    "dev:server": "nodemon -e js,jsx,html --ignore dist --ignore app/imported.js --exec 'npm run build && npm run start'",
+    "dev:server": "nodemon -e js,jsx,html --ignore dist --ignore app/imported.js --exec \"npm run build && npm run start\"",
     "format": "prettier-standard 'app/**/*.js' 'app/**/*.jsx' 'server/**/*.js'",
     "build": "rimraf dist && npm run generate-imported-components && npm run create-bundles",
     "build:nginx": "rimraf dist && npm run generate-imported-components && npm run create-bundle:nginx",


### PR DESCRIPTION
Not sure if the issue is windows 10 related or the version of nodemon on windows 10, but I found that using single quotes here was causing an error that npm could not be run via nodemon.