### PR TITLE
Windows HMR fix with Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - .:/usr/src/service
     environment:
       - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=true
     working_dir: /usr/src/service
     command: npm run dev
     ports:


### PR DESCRIPTION
This is related to https://github.com/patrickleet/streaming-ssr-react-styled-components/issues/1 I don't know why I didn't think of it at first but I think It is definitely the issue. I found this out when I first started dockerizing things on a windows machine, It totally slipped my mind. I will post a link to where it is in the docs.

> If the project runs inside a virtual machine such as (a Vagrant provisioned) VirtualBox, create an .env file in your project directory if it doesn’t exist, and add CHOKIDAR_USEPOLLING=true to it. This ensures that the next time you run npm start, the watcher uses the polling mode, as necessary inside a VM.

Bullet point number 6 here:
https://facebook.github.io/create-react-app/docs/troubleshooting#npm-start-doesn-t-detect-changes