### PR TITLE
fix: prettier-standard to lower version

### DIFF
--- a/app/pages/About.jsx
+++ b/app/pages/About.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Helmet from 'react-helmet-async'
+import {Helmet} from 'react-helmet-async'
 import Page from '../components/Page'
 
 const About = () => (

--- a/app/pages/Home.jsx
+++ b/app/pages/Home.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Helmet from 'react-helmet-async'
+import {Helmet} from 'react-helmet-async'
 import Page from '../components/Page'
 
 const Home = () => (

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lint-staged": "^8.1.0",
     "nodemon": "^1.18.9",
     "parcel-bundler": "^1.11.0",
-    "prettier-standard": "^9.1.1",
+    "prettier-standard": "9.1.1",
     "react-hot-loader": "^4.6.3",
     "rimraf": "^2.6.3"
   }


### PR DESCRIPTION
fix: prettier-standard to lower version
the new version of this library has a dependency on 'prettierx:0.11.0'
which has a dependency on 'https://github.com/ikatyang/parse-srcset'
which requires git to pull in (during Dockerfile npm ci)
which is missing in the note:11-alpine images
so it crashes there on 'RUN npm ci'
(I did not check which is the latest version that still works)